### PR TITLE
changed stack to be protected

### DIFF
--- a/java/src/net/razorvine/pickle/Unpickler.java
+++ b/java/src/net/razorvine/pickle/Unpickler.java
@@ -32,7 +32,7 @@ public class Unpickler {
 	private final int HIGHEST_PROTOCOL = 3;
 
 	private Map<Integer, Object> memo;
-	private UnpickleStack stack;
+	protected UnpickleStack stack;
 	private InputStream input;
 	private static Map<String, IObjectConstructor> objectConstructors;
 


### PR DESCRIPTION
It appears you have made the Unpickler so that it can be extended to un-pickle custom types.  The only problem I found with doing so was that I could not access the stack from my sub class.  This change allows me to un-pickle data into my own objects.
