### PR TITLE
Python Timezones (java only) 

### DIFF
--- a/java/src/net/razorvine/pickle/Pickler.java
+++ b/java/src/net/razorvine/pickle/Pickler.java
@@ -349,15 +349,10 @@ public class Pickler {
 	void put_calendar(Calendar cal) throws IOException {
 		out.write(Opcodes.GLOBAL);
 		out.write("datetime\ndatetime\n".getBytes());
-		out.write(Opcodes.MARK);
-		save(cal.get(Calendar.YEAR));
-		save(cal.get(Calendar.MONTH)+1);    // months start at 0 in java
-		save(cal.get(Calendar.DAY_OF_MONTH));
-		save(cal.get(Calendar.HOUR_OF_DAY));
-		save(cal.get(Calendar.MINUTE));
-		save(cal.get(Calendar.SECOND));
-		save(cal.get(Calendar.MILLISECOND)*1000);
-		out.write(Opcodes.TUPLE);
+		out.write(Opcodes.SHORT_BINSTRING);
+		out.write(10); // data bytes are 10 chars
+		out.write(this.datetimeDataBytes(cal));
+		out.write(Opcodes.TUPLE1);
 		out.write(Opcodes.REDUCE);
 		writeMemo(cal);
 	}
@@ -615,5 +610,22 @@ public class Pickler {
 		} catch (InvocationTargetException e) {
 			throw new PickleException("couldn't introspect javabean: "+e);
 		}
+	}
+
+	private byte[] datetimeDataBytes(Calendar cal) {
+		int microseconds = cal.get(Calendar.MILLISECOND) * 1000;
+		byte[] data = {
+				((byte) ((cal.get(Calendar.YEAR) & 0xff00) >> 8)),
+				((byte) (cal.get(Calendar.YEAR) & 0x00ff)),
+				((byte) (cal.get(Calendar.MONTH)+1)),
+				((byte) cal.get(Calendar.DAY_OF_MONTH)),
+				((byte) cal.get(Calendar.HOUR_OF_DAY)),
+				((byte) cal.get(Calendar.MINUTE)),
+				((byte) cal.get(Calendar.SECOND)),
+				((byte) ((microseconds & 0xff0000) >> 16)),
+				((byte) ((microseconds & 0x00ff00) >> 8)),
+				((byte) (microseconds & 0x0000ff)),
+		};
+		return data;
 	}
 }

--- a/java/src/net/razorvine/pickle/Unpickler.java
+++ b/java/src/net/razorvine/pickle/Unpickler.java
@@ -17,6 +17,7 @@ import net.razorvine.pickle.objects.ByteArrayConstructor;
 import net.razorvine.pickle.objects.ClassDictConstructor;
 import net.razorvine.pickle.objects.ComplexNumber;
 import net.razorvine.pickle.objects.DateTimeConstructor;
+import net.razorvine.pickle.objects.TimeZoneConstructor;
 import net.razorvine.pickle.objects.SetConstructor;
 
 /**
@@ -52,6 +53,8 @@ public class Unpickler {
 		objectConstructors.put("datetime.time", new DateTimeConstructor(DateTimeConstructor.TIME));
 		objectConstructors.put("datetime.date", new DateTimeConstructor(DateTimeConstructor.DATE));
 		objectConstructors.put("datetime.timedelta", new DateTimeConstructor(DateTimeConstructor.TIMEDELTA));
+		objectConstructors.put("pytz._UTC", new TimeZoneConstructor(TimeZoneConstructor.UTC));
+		objectConstructors.put("pytz._p", new TimeZoneConstructor(TimeZoneConstructor.PYTZ));
 		objectConstructors.put("decimal.Decimal", new AnyClassConstructor(BigDecimal.class));
 	}
 

--- a/java/src/net/razorvine/pickle/Unpickler.java
+++ b/java/src/net/razorvine/pickle/Unpickler.java
@@ -18,6 +18,7 @@ import net.razorvine.pickle.objects.ClassDictConstructor;
 import net.razorvine.pickle.objects.ComplexNumber;
 import net.razorvine.pickle.objects.DateTimeConstructor;
 import net.razorvine.pickle.objects.TimeZoneConstructor;
+import net.razorvine.pickle.objects.Reconstructor;
 import net.razorvine.pickle.objects.SetConstructor;
 
 /**
@@ -55,7 +56,10 @@ public class Unpickler {
 		objectConstructors.put("datetime.timedelta", new DateTimeConstructor(DateTimeConstructor.TIMEDELTA));
 		objectConstructors.put("pytz._UTC", new TimeZoneConstructor(TimeZoneConstructor.UTC));
 		objectConstructors.put("pytz._p", new TimeZoneConstructor(TimeZoneConstructor.PYTZ));
+		objectConstructors.put("dateutil.tz.tzutc", new TimeZoneConstructor(TimeZoneConstructor.DATEUTIL_TZUTC));
+		objectConstructors.put("datetime.tzinfo", new TimeZoneConstructor(TimeZoneConstructor.TZINFO));
 		objectConstructors.put("decimal.Decimal", new AnyClassConstructor(BigDecimal.class));
+		objectConstructors.put("copy_reg._reconstructor", new Reconstructor());
 	}
 
 	/**

--- a/java/src/net/razorvine/pickle/objects/DateTimeConstructor.java
+++ b/java/src/net/razorvine/pickle/objects/DateTimeConstructor.java
@@ -2,6 +2,7 @@ package net.razorvine.pickle.objects;
 
 import java.util.Calendar;
 import java.util.GregorianCalendar;
+import java.util.TimeZone;
 
 import net.razorvine.pickle.IObjectConstructor;
 import net.razorvine.pickle.PickleException;
@@ -65,8 +66,8 @@ public class DateTimeConstructor implements IObjectConstructor {
 			cal.set(Calendar.MILLISECOND, microsec/1000);
 			return cal;
 		}
-		if (args.length != 1)
-			throw new PickleException("invalid pickle data for datetime; expected 1 or 7 args, got "+args.length);
+		if (args.length != 1 && args.length != 2)
+			throw new PickleException("invalid pickle data for datetime; expected 1, 2 or 7 args, got "+args.length);
 		
 		int yhi, ylo, month, day, hour, minute, second, microsec;
 		if(args[0] instanceof String) {
@@ -102,6 +103,16 @@ public class DateTimeConstructor implements IObjectConstructor {
 		}
 		Calendar cal = new GregorianCalendar(yhi * 256 + ylo, month, day, hour, minute, second);
 		cal.set(Calendar.MILLISECOND, microsec/1000);
+		if(args.length == 2) {
+			// Timezone passed as the second constructor arg in pickle protocal 0
+			if (args[1] instanceof TimeZone)
+				cal.setTimeZone((TimeZone) args[1]);
+			else if (args[1] instanceof Tzinfo) {
+				cal.setTimeZone(((Tzinfo) args[1]).getTimeZone());
+			} else {
+				throw new PickleException("invalid pickle data for datetime; expected arg 2 to be a Tzinfo or TimeZone");
+			}
+		}
 		return cal;
 	}
 

--- a/java/src/net/razorvine/pickle/objects/Reconstructor.java
+++ b/java/src/net/razorvine/pickle/objects/Reconstructor.java
@@ -1,0 +1,28 @@
+package net.razorvine.pickle.objects;
+
+import net.razorvine.pickle.IObjectConstructor;
+import net.razorvine.pickle.PickleException;
+import net.razorvine.pickle.objects.Tzinfo;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.TimeZone;
+
+/**
+ * This constructor is called by the helper methods that pickle protocol 0
+ * uses from the python copy_reg module to reconstruct c objects.
+ */
+public class Reconstructor implements IObjectConstructor {
+    public Object construct(Object[] args) {
+        if(args.length != 3)
+            throw new PickleException("invalid pickle data; expecting 3 args to copy_reg reconstructor but recieved " + args.length);
+
+        Object reconstructor = args[0];
+        try {
+            Method reconstruct=reconstructor.getClass().getMethod("reconstruct", Object.class, Object.class);
+            return reconstruct.invoke(reconstructor, args[1], args[2]);
+        } catch (Exception e) {
+            throw new PickleException("failed to reconstruct()", e);
+        }
+    }
+}

--- a/java/src/net/razorvine/pickle/objects/TimeZoneConstructor.java
+++ b/java/src/net/razorvine/pickle/objects/TimeZoneConstructor.java
@@ -8,6 +8,8 @@ import java.util.TimeZone;
 public class TimeZoneConstructor implements IObjectConstructor {
 	public static int UTC = 1;
 	public static int PYTZ = 2;
+	public static int DATEUTIL_TZUTC = 3;
+	public static int TZINFO = 4;
 
 	private int pythontype;
 
@@ -21,14 +23,44 @@ public class TimeZoneConstructor implements IObjectConstructor {
 		return createUTC();
 	if (this.pythontype == PYTZ)
 		return createZoneFromPytz(args);
+	if (this.pythontype == DATEUTIL_TZUTC)
+		return createInfoFromDateutilTzutc(args);
+	if (this.pythontype == TZINFO)
+		return createInfo(args);
 
 	throw new PickleException("invalid object type");
+	}
+
+	public Object reconstruct(Object baseConstructor, Object state) {
+		if (!(state instanceof Tzinfo))
+			throw new PickleException("invalid pickle data for tzinfo reconstruction; expected emtpy tzinfo state class");
+		if (!(baseConstructor instanceof TimeZoneConstructor))
+			throw new PickleException("invalid pickle data for tzinfo reconstruction; expected a TimeZoneConstructor from a known tzinfo subclass");
+
+		// The subclass (this) is reconstructing the state given the base class and state. If it is known that the
+		// subclass is always UTC, ie dateutil.tz.tzutc, then we can just return the timezone we know matches that.
+		if (this.pythontype == DATEUTIL_TZUTC) {
+			return TimeZone.getTimeZone("UTC");
+		} else {
+			throw new PickleException("unsupported pickle data for tzinfo reconstruction; support for tzinfo subclasses other than tztuc has not been implemented");
+		}
+	}
+
+	private Object createInfo(Object[] args) {
+		// args is empty, datetime.tzinfo objects are unpickled via setstate, so return an object which is ready to have it's state set
+		return new Tzinfo();
+	}
+
+	private Object createInfoFromDateutilTzutc(Object[] args) {
+		// In the case of the dateutil.tz.tzutc constructor, which is a python subclass of the datetime.tzinfo class, there is no state
+		// to set, because the zone is implied by the constructor. Pass the timezone indicated by hte constructor here
+		return new Tzinfo(TimeZone.getTimeZone("UTC"));
 	}
 
 	private Object createZoneFromPytz(Object[] args) {
 
 		if (args.length != 4 && args.length != 1)
-			throw new PickleException("invalid pickle data for pytz timezone; expected 2 or 4 args, got " + args.length);
+			throw new PickleException("invalid pickle data for pytz timezone; expected 1 or 4 args, got " + args.length);
 
 		// args can be a tuple of 4 values: string timezone identifier, int seconds from utc offset, int seconds for DST, string python timezone name
 		// if args came from a pytz.DstTzInfo object

--- a/java/src/net/razorvine/pickle/objects/TimeZoneConstructor.java
+++ b/java/src/net/razorvine/pickle/objects/TimeZoneConstructor.java
@@ -1,0 +1,47 @@
+package net.razorvine.pickle.objects;
+
+import net.razorvine.pickle.IObjectConstructor;
+import net.razorvine.pickle.PickleException;
+import net.razorvine.pickle.objects.Tzinfo;
+import java.util.TimeZone;
+
+public class TimeZoneConstructor implements IObjectConstructor {
+	public static int UTC = 1;
+	public static int PYTZ = 2;
+
+	private int pythontype;
+
+	public TimeZoneConstructor(int pythontype) {
+		this.pythontype = pythontype;
+	}
+	
+	@Override
+	public Object construct(Object[] args) throws PickleException {
+	if (this.pythontype == UTC)
+		return createUTC();
+	if (this.pythontype == PYTZ)
+		return createZoneFromPytz(args);
+
+	throw new PickleException("invalid object type");
+	}
+
+	private Object createZoneFromPytz(Object[] args) {
+
+		if (args.length != 4 && args.length != 1)
+			throw new PickleException("invalid pickle data for pytz timezone; expected 2 or 4 args, got " + args.length);
+
+		// args can be a tuple of 4 values: string timezone identifier, int seconds from utc offset, int seconds for DST, string python timezone name
+		// if args came from a pytz.DstTzInfo object
+		// Or, args is a tuple of 1 value: string timezone identifier
+		// if args came from a pytz.StaticTzInfo object
+		// In both cases we can ask the system for a timezone with that identifier and it should find one with that identifier if python did.
+
+		if (!(args[0] instanceof String))
+			throw new PickleException("invalid pickle data for pytz timezone; expected string argument as first tuple member");
+		return TimeZone.getTimeZone((String) args[0]);
+	}
+
+	private Object createUTC() {
+		return TimeZone.getTimeZone("UTC");
+	}
+}

--- a/java/src/net/razorvine/pickle/objects/Tzinfo.java
+++ b/java/src/net/razorvine/pickle/objects/Tzinfo.java
@@ -1,0 +1,37 @@
+package net.razorvine.pickle.objects;
+
+import java.util.HashMap;
+import java.util.TimeZone;
+import net.razorvine.pickle.PickleException;
+
+/**
+ * Timezone offset class that implements __setstate__ for the unpickler
+ * to track what TimeZone a dateutil.tz.tzoffset or tzutc should unpickle to
+ */
+public class Tzinfo {
+
+    private boolean forceTimeZone;
+    private TimeZone timeZone;
+
+    public Tzinfo(TimeZone timeZone) {
+        this.forceTimeZone = true;
+        this.timeZone = timeZone;
+    }
+
+    public Tzinfo() {
+        this.forceTimeZone = false;
+    }
+
+    public TimeZone getTimeZone() {
+        return this.timeZone;
+    }
+
+    /**
+     * called by the unpickler to restore state
+     */
+    public void __setstate__(HashMap<String,Object> args) {
+        if (this.forceTimeZone)
+            return;
+        throw new PickleException("unexpected pickle data for tzinfo objects: can't __setstate__ with anything other than an empty dict, anything else is unimplemented");
+    }
+}

--- a/java/test/net/razorvine/pickle/test/PicklerTests.java
+++ b/java/test/net/razorvine/pickle/test/PicklerTests.java
@@ -23,6 +23,7 @@ import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.Stack;
 import java.util.Vector;
+import java.util.TimeZone;
 
 import net.razorvine.pickle.IObjectPickler;
 import net.razorvine.pickle.Opcodes;
@@ -249,6 +250,28 @@ public class PicklerTests {
 		o=p.dumps(cal);
 		unpickled=u.loads(o);
 		assertEquals(cal,(Calendar)unpickled);
+
+		TimeZone tz = TimeZone.getTimeZone("America/New_York");
+		cal=new GregorianCalendar(2011,Calendar.DECEMBER,31,14,33,59);
+		cal.set(Calendar.MILLISECOND, 456);
+		cal.setTimeZone(tz);
+
+		o=p.dumps(cal);
+		unpickled=u.loads(o);
+		assertEquals(cal, (Calendar) unpickled);
+		assertEquals(tz, ((Calendar) unpickled).getTimeZone());
+
+		// example ambiguous DST datetime where the zone is in DST and the time occurs in the transition
+		// period, which means two different datetimes could come back
+		tz = TimeZone.getTimeZone("America/St_Johns");
+		cal=new GregorianCalendar(2009, Calendar.OCTOBER, 31, 23, 30, 59);
+		cal.set(Calendar.MILLISECOND, 456);
+		cal.setTimeZone(tz);
+
+		o=p.dumps(cal);
+		unpickled=u.loads(o);
+		assertEquals(cal, (Calendar) unpickled);
+		assertEquals(tz, ((Calendar) unpickled).getTimeZone());
 	}
 	
 	@Test

--- a/java/test/net/razorvine/pickle/test/UnpicklerTests.java
+++ b/java/test/net/razorvine/pickle/test/UnpicklerTests.java
@@ -11,6 +11,7 @@ import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.TimeZone;
 
 import net.razorvine.pickle.PickleException;
 import net.razorvine.pickle.PickleUtils;
@@ -304,6 +305,51 @@ public class UnpicklerTests {
 		assertEquals(c, c2);
 		c2 = (Calendar) U("cdatetime\ndatetime\np0\n(S\"\\x07\\xdb\\n\\t\\r\\n\\t\\x00\'\\x10\"\np1\ntp2\nRp3\n.");	// protocol 0
 		assertEquals(c, c2);
+	}
+	
+	@Test
+	public void testDateTimeWithTimezones() throws PickleException, IOException
+	{
+		TimeZone tz = TimeZone.getTimeZone("UTC");
+		Calendar c=new GregorianCalendar(2014, Calendar.JULY, 8);
+		c.set(Calendar.HOUR_OF_DAY, 10);
+		c.set(Calendar.MINUTE, 10);
+		c.set(Calendar.SECOND, 0);
+		c.set(Calendar.MILLISECOND, 0);
+		c.setTimeZone(tz);
+
+		// pytz timezones that are utc
+		Calendar pc=(Calendar) U("cdatetime\ndatetime\np0\n(S'\\x07\\xde\\x07\\x08\\n\\n\\x00\\x00\\x00\\x00'\np1\ncpytz\n_UTC\np2\n(tRp3\ntp4\nRp5\n.");
+		assertEquals(c.getTimeInMillis(), pc.getTimeInMillis());
+		pc=(Calendar) U("\u0080\u0002cdatetime\ndatetime\nq\u0000U\n\u0007\u00de\u0007\u0008\n\n\u0000\u0000\u0000\u0000q\u0001cpytz\n_UTC\nq\u0002)Rq\u0003\u0086q\u0004Rq\u0005.");
+		assertEquals(c.getTimeInMillis(), pc.getTimeInMillis());
+		tz = TimeZone.getTimeZone("America/New_York");
+		c=new GregorianCalendar(2014, Calendar.JULY, 8);
+		c.set(Calendar.HOUR_OF_DAY, 10);
+		c.set(Calendar.MINUTE, 10);
+		c.set(Calendar.SECOND, 0);
+		c.set(Calendar.MILLISECOND, 0);
+		c.setTimeZone(tz);
+
+		// pytz timezones with DST support
+		pc=(Calendar) U("cdatetime\ndatetime\np0\n(S\'\\x07\\xde\\x07\\x08\\n\\n\\x00\\x00\\x00\\x00\'\np1\ncpytz\n_p\np2\n(VAmerica/New_York\np3\nI-17760\nI0\nVLMT\np4\ntp5\nRp6\ntp7\nRp8\n.");
+		assertEquals(c.getTimeInMillis(), pc.getTimeInMillis());
+		pc=(Calendar) U("\u0080\u0002cdatetime\ndatetime\nq\u0000U\n\u0007\u00de\u0007\u0008\n\n\u0000\u0000\u0000\u0000q\u0001cpytz\n_p\nq\u0002(X\u0010\u0000\u0000\u0000America/New_Yorkq\u0003J\u00a0\u00ba\u00ff\u00ffK\u0000X\u0003\u0000\u0000\u0000LMTq\u0004tq\u0005Rq\u0006\u0086q\u0007Rq\u0008.");
+		assertEquals(c.getTimeInMillis(), pc.getTimeInMillis());
+
+		tz = TimeZone.getTimeZone("MST");
+		c=new GregorianCalendar(2014, Calendar.JULY, 8);
+		c.set(Calendar.HOUR_OF_DAY, 10);
+		c.set(Calendar.MINUTE, 10);
+		c.set(Calendar.SECOND, 0);
+		c.set(Calendar.MILLISECOND, 0);
+		c.setTimeZone(tz);
+
+		// pytz timezones with static offsets
+		pc=(Calendar) U("cdatetime\ndatetime\np0\n(S\'\\x07\\xde\\x07\\x08\\n\\n\\x00\\x00\\x00\\x00\'\np1\ncpytz\n_p\np2\n(S\'MST\'\np3\ntp4\nRp5\ntp6\nRp7\n.");
+		assertEquals(c.getTimeInMillis(), pc.getTimeInMillis());
+		pc=(Calendar) U("\u0080\u0002cdatetime\ndatetime\nq\u0000U\n\u0007\u00de\u0007\u0008\n\n\u0000\u0000\u0000\u0000q\u0001cpytz\n_p\nq\u0002U\u0003MSTq\u0003\u0085q\u0004Rq\u0005\u0086q\u0006Rq\u0007.");
+		assertEquals(c.getTimeInMillis(), pc.getTimeInMillis());
 	}
 	
 	@Test

--- a/java/test/net/razorvine/pickle/test/UnpicklerTests.java
+++ b/java/test/net/razorvine/pickle/test/UnpicklerTests.java
@@ -323,6 +323,13 @@ public class UnpicklerTests {
 		assertEquals(c.getTimeInMillis(), pc.getTimeInMillis());
 		pc=(Calendar) U("\u0080\u0002cdatetime\ndatetime\nq\u0000U\n\u0007\u00de\u0007\u0008\n\n\u0000\u0000\u0000\u0000q\u0001cpytz\n_UTC\nq\u0002)Rq\u0003\u0086q\u0004Rq\u0005.");
 		assertEquals(c.getTimeInMillis(), pc.getTimeInMillis());
+
+		// dateutil tzutcs
+		pc=(Calendar) U("cdatetime\ndatetime\np0\n(S\'\\x07\\xde\\x07\\x08\\n\\n\\x00\\x00\\x00\\x00\'\np1\nccopy_reg\n_reconstructor\np2\n(cdateutil.tz\ntzutc\np3\ncdatetime\ntzinfo\np4\ng4\n(tRp5\ntp6\nRp7\ntp8\nRp9\n.");
+		assertEquals(c.getTimeInMillis(), pc.getTimeInMillis());
+		pc=(Calendar) U("\u0080\u0002cdatetime\ndatetime\nq\u0000U\n\u0007\u00de\u0007\u0008\n\n\u0000\u0000\u0000\u0000q\u0001cdateutil.tz\ntzutc\nq\u0002)\u0081q\u0003}q\u0004b\u0086q\u0005Rq\u0006.");
+		assertEquals(c.getTimeInMillis(), pc.getTimeInMillis());
+
 		tz = TimeZone.getTimeZone("America/New_York");
 		c=new GregorianCalendar(2014, Calendar.JULY, 8);
 		c.set(Calendar.HOUR_OF_DAY, 10);


### PR DESCRIPTION
This adds support for depickling most of the commonly used timezone representations from Python in Java land. 

 - Adds a TimeZoneConstructor which converts pickled timezone representations of timezones into java.util.TimeZone objects
 - Adds support for the two argument tuple in the DateTimeConstructor, the inner date’s state and the timezone
 - Add support for depickling python datetime objects with `dateutil.tz.tzutc` objects as their timezone

This is tricky for a couple reasons. For protocol 0 and 1, Python didn’t use `__setstate__` to unpickle objects implemented in C, it used functions from the copy_reg module. So, unlike pytz timezone objects which are implemented in python, the datetime.tzinfo standard library timezone class gets pickled using a “constructor” of `copy_reg._reconstructor` in protocol 0. Further complicating things is that the object that almost everyone uses, `dateutil.tz.tzutc`, is a subclass of this C class. This is pickled as a call to the `_reconstructor` function with three arguments: the subclass or “real” class we are trying to create, the base class which is implemented in C land, and the state that the eventual object we are trying to depickle should have. The reconstructor then allocates a new instance of the base class with `__new__`, but passes the sub class as the class to mark the object as. So the underlying C class does the allocation, but out comes an allocated instance of the fancy sub class. Yeeesh. Then, `_reconstructor` calls the base classes’ `__init__` with the state to actually set the object back up again.

I opted to not really try to implement this logic cause IMO it’s crazy, and a deprecated protocol. Instead, I short cutted. I implemented a Pyrolite land version of the `_reconstructor` function which checks the “sub class” (given to it as a configured IObjectConstructor of some sort) to see if it knows how to reconstruct an object given the “base class” and “state”, which are from the unpickle stack. It uses reflection to check for a `reconstruct` function on the constructor. I then added an implementation of reconstruct to the TimeZoneConstructor so it can check for the very specific conditions that indicate we’re trying to unpickle a `dateutil.tz.tzutc` object, and just leverage the fact that we know it’s UTC and return a UTC TimeZone there. This is all, which means there is no support for unpickling other objects that are subclasses of C classes, like other things in dateutil, like `dateutil.tz.tzlocal`. This is something we could add in the future but requires making the code even more complex and confusing. I think it can be avoided for now since I am the first person to need this functionality, and I know I don’t need tzlocal support, since I feel as though most people stay away from those objects since they don’t support DST properly, and stick with pytz objects, which were easier to implement in the previous commit.

For protocol 2, `__setstate__` is a thing, so I added a Tzinfo object which knows how to be depickled and have it’s state set. The DateTimeConstructor then knows how to be passed a Tzinfo object and ask it for its TimeZone so it can set that on the returned Calendar. Thing is, a `dateutil.tz.tzutc` object doesn’t actually have any state, womp womp. The timezone for it is simply implied by the name of the constructor as far as I can tell. This means that some object somewhere has to know that, so I did something somewhat dirty and make the tzinfo constructor understand when it needs to force itself to UTC. This means that the `__setstate__` is called on the tzinfo object, but with no state, and has no effect, because the object previously learned what java-land TimeZone object it should represent when it was constructed, as that’s the only point in time where we knew the name of the constructor.

Yuck.

@irmen feel free to have a look whenever it's convienient and please let me know if I can change things around, I have not done much java at all. 

@udnay maybe you could give me a quick code review as well if you have time. 

Fixes #19 