### PR TITLE
Implement timezone unpickles for dateutil.tz.tzfile and dateutil.zoneinfo.gettz

### DIFF
--- a/java/src/net/razorvine/pickle/Pickler.java
+++ b/java/src/net/razorvine/pickle/Pickler.java
@@ -393,12 +393,18 @@ public class Pickler {
 
 	void put_timezone(TimeZone timeZone) throws IOException {
 		out.write(Opcodes.GLOBAL);
-		out.write("pytz\n_p\n".getBytes());
-		out.write(Opcodes.MARK);
-		save(timeZone.getID());
-		save(timeZone.getRawOffset() / 1000);
-		save(timeZone.getDSTSavings() / 1000);
-		save(timeZone.getDisplayName(timeZone.observesDaylightTime(), TimeZone.SHORT));
+		if (timeZone.getID().equals("UTC")) {
+			out.write("pytz\n_UTC\n".getBytes());
+			out.write(Opcodes.MARK);
+		} else {
+			out.write("pytz\n_p\n".getBytes());
+			out.write(Opcodes.MARK);
+			save(timeZone.getID());
+			save(timeZone.getRawOffset() / 1000);
+			save(timeZone.getDSTSavings() / 1000);
+			save(timeZone.getDisplayName(timeZone.observesDaylightTime(), TimeZone.SHORT));
+		}
+
 		out.write(Opcodes.TUPLE);
 		out.write(Opcodes.REDUCE);
 		writeMemo(timeZone);

--- a/java/src/net/razorvine/pickle/Unpickler.java
+++ b/java/src/net/razorvine/pickle/Unpickler.java
@@ -58,6 +58,7 @@ public class Unpickler {
 		objectConstructors.put("pytz._p", new TimeZoneConstructor(TimeZoneConstructor.PYTZ));
 		objectConstructors.put("dateutil.tz.tzutc", new TimeZoneConstructor(TimeZoneConstructor.DATEUTIL_TZUTC));
 		objectConstructors.put("dateutil.tz.tzfile", new TimeZoneConstructor(TimeZoneConstructor.DATEUTIL_TZFILE));
+		objectConstructors.put("dateutil.zoneinfo.gettz", new TimeZoneConstructor(TimeZoneConstructor.DATEUTIL_GETTZ));
 		objectConstructors.put("datetime.tzinfo", new TimeZoneConstructor(TimeZoneConstructor.TZINFO));
 		objectConstructors.put("decimal.Decimal", new AnyClassConstructor(BigDecimal.class));
 		objectConstructors.put("copy_reg._reconstructor", new Reconstructor());

--- a/java/src/net/razorvine/pickle/Unpickler.java
+++ b/java/src/net/razorvine/pickle/Unpickler.java
@@ -57,6 +57,7 @@ public class Unpickler {
 		objectConstructors.put("pytz._UTC", new TimeZoneConstructor(TimeZoneConstructor.UTC));
 		objectConstructors.put("pytz._p", new TimeZoneConstructor(TimeZoneConstructor.PYTZ));
 		objectConstructors.put("dateutil.tz.tzutc", new TimeZoneConstructor(TimeZoneConstructor.DATEUTIL_TZUTC));
+		objectConstructors.put("dateutil.tz.tzfile", new TimeZoneConstructor(TimeZoneConstructor.DATEUTIL_TZFILE));
 		objectConstructors.put("datetime.tzinfo", new TimeZoneConstructor(TimeZoneConstructor.TZINFO));
 		objectConstructors.put("decimal.Decimal", new AnyClassConstructor(BigDecimal.class));
 		objectConstructors.put("copy_reg._reconstructor", new Reconstructor());

--- a/java/src/net/razorvine/pickle/objects/TimeZoneConstructor.java
+++ b/java/src/net/razorvine/pickle/objects/TimeZoneConstructor.java
@@ -10,6 +10,7 @@ public class TimeZoneConstructor implements IObjectConstructor {
 	public static int PYTZ = 2;
 	public static int DATEUTIL_TZUTC = 3;
 	public static int DATEUTIL_TZFILE = 4;
+	public static int DATEUTIL_GETTZ = 5;
 	public static int TZINFO = 6;
 
 	private int pythontype;
@@ -28,6 +29,8 @@ public class TimeZoneConstructor implements IObjectConstructor {
 		return createInfoFromDateutilTzutc(args);
 	if (this.pythontype == DATEUTIL_TZFILE)
 		return createInfoFromDateutilTzfile(args);
+	if (this.pythontype == DATEUTIL_GETTZ)
+		return createInfoFromDateutilGettz(args);
 	if (this.pythontype == TZINFO)
 		return createInfo(args);
 
@@ -76,6 +79,16 @@ public class TimeZoneConstructor implements IObjectConstructor {
 		}
 		return new Tzinfo(TimeZone.getTimeZone(identifier));
 	}
+
+	private Object createInfoFromDateutilGettz(Object[] args) {
+		if (args.length != 1)
+			throw new PickleException("invalid pickle data for dateutil gettz call; expected 1 args, got " + args.length);
+
+		// In the case of the dateutil.tz.gettz function call, we're passed one string identifier of the the timezone.
+		String identifier = (String) args[0];
+		return new Tzinfo(TimeZone.getTimeZone(identifier));
+	}
+
 	private Object createZoneFromPytz(Object[] args) {
 
 		if (args.length != 4 && args.length != 1)

--- a/java/test/net/razorvine/pickle/test/PicklerTests.java
+++ b/java/test/net/razorvine/pickle/test/PicklerTests.java
@@ -272,6 +272,18 @@ public class PicklerTests {
 		unpickled=u.loads(o);
 		assertEquals(cal, (Calendar) unpickled);
 		assertEquals(tz, ((Calendar) unpickled).getTimeZone());
+
+		// example UTC timezone which pytz differently to a special constructor
+		tz = TimeZone.getTimeZone("UTC");
+		cal=new GregorianCalendar(2011,Calendar.DECEMBER,31,14,33,59);
+		cal.set(Calendar.MILLISECOND, 456);
+		cal.setTimeZone(tz);
+
+		o=p.dumps(cal);
+		assertArrayEquals(B("cdatetime\ndatetime\nU\n\u0007Û\f\u001F\u000E!;\u0006õ@cpytz\n_UTC\n(tR\u0086R"), o); // ensure pickling uses the _UTC constructor
+		unpickled=u.loads(o);
+		assertEquals(cal, (Calendar) unpickled);
+		assertEquals(tz, ((Calendar) unpickled).getTimeZone());
 	}
 	
 	@Test

--- a/java/test/net/razorvine/pickle/test/UnpicklerTests.java
+++ b/java/test/net/razorvine/pickle/test/UnpicklerTests.java
@@ -359,6 +359,24 @@ public class UnpicklerTests {
 		assertEquals(c.getTimeInMillis(), pc.getTimeInMillis());
 		
 		// dateutil gettz timezone
+		tz = TimeZone.getTimeZone("Europe/Amsterdam");
+		c=new GregorianCalendar(2015, Calendar.APRIL, 9);
+		c.set(Calendar.HOUR_OF_DAY, 19);
+		c.set(Calendar.MINUTE, 6);
+		c.set(Calendar.SECOND, 26);
+		c.set(Calendar.MILLISECOND, 472);
+		c.setTimeZone(tz);
+
+		pc=(Calendar) U("cdatetime\ndatetime\np0\n(S\'\\x07\\xdf\\x04\\t\\x13\\x06\\x1a\\x073\\xcc\'\np1\ncdateutil.tz\ntzfile\np2\n(S\'/usr/share/zoneinfo/Europe/Amsterdam\'\np3\ntp4\nRp5\ntp6\nRp7\n.");
+		assertEquals(c.getTimeInMillis(), pc.getTimeInMillis());
+		pc=(Calendar) U("\u0080\u0002cdatetime\ndatetime\nq\u0000U\n\u0007\u00df\u0004\t\u0013\u0006\u001a\u00073\u00ccq\u0001cdateutil.tz\ntzfile\nq\u0002U$/usr/share/zoneinfo/Europe/Amsterdamq\u0003\u0085q\u0004Rq\u0005\u0086q\u0006Rq\u0007.");
+		assertEquals(c.getTimeInMillis(), pc.getTimeInMillis());
+
+		// multi word dateutil gettz timezone
+		pc=(Calendar) U("cdatetime\ndatetime\np0\n(S\'\\x07\\xdf\\x04\\n\\x0f\\x17\\x13\\x07\\xdf\\x91\'\np1\ncdateutil.tz\ntzfile\np2\n(S\'/usr/share/zoneinfo/America/New_York\'\np3\ntp4\nRp5\ntp6\nRp7\n.");
+		assertEquals("America/New_York", pc.getTimeZone().getID());
+
+		// dateutil gettz timezone without full path to the zoneinfo file
 		pc=(Calendar) U("\u0080\u0002cdatetime\ndatetime\nU\n\u0007\u00df\u0004\u0006\u000e*.\u0000a\u00a8cdateutil.zoneinfo\ngettz\nU\u0010Europe/Amsterdam\u0085R\u0086R.");
 		assertEquals("Europe/Amsterdam", c.getTimeZone().getID());
 	}

--- a/java/test/net/razorvine/pickle/test/UnpicklerTests.java
+++ b/java/test/net/razorvine/pickle/test/UnpicklerTests.java
@@ -378,7 +378,7 @@ public class UnpicklerTests {
 
 		// dateutil gettz timezone without full path to the zoneinfo file
 		pc=(Calendar) U("\u0080\u0002cdatetime\ndatetime\nU\n\u0007\u00df\u0004\u0006\u000e*.\u0000a\u00a8cdateutil.zoneinfo\ngettz\nU\u0010Europe/Amsterdam\u0085R\u0086R.");
-		assertEquals("Europe/Amsterdam", c.getTimeZone().getID());
+		assertEquals("Europe/Amsterdam", pc.getTimeZone().getID());
 	}
 	
 	@Test


### PR DESCRIPTION
This adds support for unpickling the two different kinds of `tzinfo` pickles `python-dateutil` seems to make. I don't know if this is an exhaustive list, sorry :(

 - Add support for unpickling timezones pickled as references to `dateutil.zoneinfo.gettz` which fixes the failing test from 15025b4
 - Also add support for unpickling python timezones pickled as references to a `dateutil.tz.tzfile` object. This one is a bit trickier. The disassembled pickle looks like this:

```
    0: \x80 PROTO      2
    2: c    GLOBAL     'datetime datetime'
   21: q    BINPUT     0
   23: U    SHORT_BINSTRING '\x07\xdf\x04\n\x15\x08\x15\nn!'
   35: q    BINPUT     1
   37: c    GLOBAL     'dateutil.tz tzfile'
   57: q    BINPUT     2
   59: U    SHORT_BINSTRING '/usr/share/zoneinfo/Europe/Amsterdam'
   97: q    BINPUT     3
   99: \x85 TUPLE1
  100: q    BINPUT     4
  102: R    REDUCE
  103: q    BINPUT     5
  105: \x86 TUPLE2
  106: q    BINPUT     6
  108: R    REDUCE
  109: q    BINPUT     7
  111: .    STOP
```

which as you can see doesn't embed the time zone identifier in the pickle data, but instead a fully qualified path to the tzinfo file on the filesystem. The trick is getting the identifier part from this path in a robust way. I opted to implement a dead simple hacky algorithm: take everything after the "zoneinfo/" in the path and treat it as the identifier. I happily admit this sucks but I am not really sure if there is much else to do short of reading and somehow parsing the tzinfo file, which might not always work if we're on a different system and even then a quick glance at the contents of those files says they don't even have the ID in them, just the offset and whatnot. On my local OS X system and in my linux production env the path to the zoneinfos is always '/usr/share/zoneinfo' but I don't know how consistent that is :(

Thoughts?

/cc @yagnik this is what's blocking Avro still