### PR TITLE
Add a simple build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,21 @@
+name := "pyrolite"
+
+organization := "com.github.irmen"
+
+version := "4.5-SNAPSHOT"
+
+libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test"
+
+unmanagedBase := baseDirectory.value / "java" / "lib"
+
+scalacOptions += "-target:jvm-1.6"
+
+crossPaths := false
+
+autoScalaLibrary := false
+
+javaSource in Compile := baseDirectory.value / "java" / "src"
+
+javaSource in Test := baseDirectory.value / "java" / "test"
+
+testOptions += Tests.Argument(TestFrameworks.JUnit, "-q", "-v")


### PR DESCRIPTION
@irmen This is an SBT build file for Pyrolite. You can do the following:

1. `sbt compile`, compile the source code
2. `sbt test`, run all tests
3. `sbt publish-m2`, publish jars and generate pom file to your local `~/.m2` folder

I feel this is easier to configure than `ant`, while I fully understand if you don't want to add complexity to the existing build.