### PR TITLE
Improve pickling/unpickling performance 

### DIFF
--- a/dotnet/Pyrolite.nuspec
+++ b/dotnet/Pyrolite.nuspec
@@ -20,7 +20,8 @@ Razorvine.Serpent library dependency updated to 1.18.
     <copyright>Copyright 2015, 2016, 2017, 2018</copyright>
     <tags>pyro python rpc remote-objects</tags>
 	  <dependencies>
-	  	<dependency id="Razorvine.Serpent" version="1.18" />
+      <dependency id="Razorvine.Serpent" version="1.18" />
+      <dependency id="System.Memory" version="4.5.2" />
   	</dependencies>
   </metadata>
   <files>

--- a/dotnet/Razorvine.Pyrolite/Pyrolite/Pickle/Objects/ArrayConstructor.cs
+++ b/dotnet/Razorvine.Pyrolite/Pyrolite/Pickle/Objects/ArrayConstructor.cs
@@ -1,6 +1,7 @@
 /* part of Pyrolite, by Irmen de Jong (irmen@razorvine.net) */
 
 using System;
+using System.Buffers.Binary;
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 
@@ -43,99 +44,88 @@ public class ArrayConstructor : IObjectConstructor {
 		case 'u':// Unicode character 2 -> char[]
 		{
 			var result = new char[values.Count];
-			int i = 0;
-			foreach(var c in values) {
-				result[i++] = ((string) c)[0];
+            for (int i = 0; i < result.Length; i++) {
+				result[i] = ((string) values[i])[0];
 			}
 			return result;
 		}
 		case 'b':// signed char -> sbyte[]
 		{
 			var result = new sbyte[values.Count];
-			int i = 0;
-			foreach(var c in values) {
-				result[i++] = Convert.ToSByte(c);
+            for (int i = 0; i < result.Length; i++) {
+				result[i] = Convert.ToSByte(values[i]);
 			}
 			return result;
 		}
 		case 'B':// unsigned char -> byte[]
 		{
 			var result = new byte[values.Count];
-			int i = 0;
-			foreach(var c in values) {
-				result[i++] = Convert.ToByte(c);
+            for (int i = 0; i < result.Length; i++) {
+				result[i] = Convert.ToByte(values[i]);
 			}
 			return result;
 		}
 		case 'h':// signed short -> short[]
 		{
 			var result = new short[values.Count];
-			int i = 0;
-			foreach(var c in values) {
-				result[i++] = Convert.ToInt16(c);
+            for (int i = 0; i < result.Length; i++) {
+				result[i] = Convert.ToInt16(values[i]);
 			}
 			return result;
 		}
 		case 'H':// unsigned short -> ushort[]
 		{
 			var result = new ushort[values.Count];
-			int i = 0;
-			foreach(var c in values) {
-				result[i++] = Convert.ToUInt16(c);
+            for (int i = 0; i < result.Length; i++) {
+				result[i] = Convert.ToUInt16(values[i]);
 			}
 			return result;
 		}
 		case 'i':// signed integer -> int[]
 		{
 			var result = new int[values.Count];
-			int i = 0;
-			foreach(var c in values) {
-				result[i++] = Convert.ToInt32(c);
+            for (int i = 0; i < result.Length; i++) {
+				result[i] = Convert.ToInt32(values[i]);
 			}
 			return result;
 		}
 		case 'I':// unsigned integer 4 -> uint[]
 		{
 			var result = new uint[values.Count];
-			int i = 0;
-			foreach(var c in values) {
-				result[i++] = Convert.ToUInt32(c);
+            for (int i = 0; i < result.Length; i++) {
+				result[i] = Convert.ToUInt32(values[i]);
 			}
 			return result;
 		}
 		case 'l':// signed long -> long[]
 		{
 			var result = new long[values.Count];
-			int i = 0;
-			foreach(var c in values) {
-				result[i++] = Convert.ToInt64(c);
+            for (int i = 0; i < result.Length; i++) {
+				result[i] = Convert.ToInt64(values[i]);
 			}
 			return result;
 		}
 		case 'L':// unsigned long -> ulong[]
 		{
 			var result = new ulong[values.Count];
-			int i = 0;
-			foreach(var c in values) {
-				result[i++] = Convert.ToUInt64(c);
+            for (int i = 0; i < result.Length; i++) {
+				result[i] = Convert.ToUInt64(values[i]);
 			}
 			return result;
 		}
 		case 'f':// floating point 4 -> float[]
 		{
 			var result = new float[values.Count];
-			int i = 0;
-			foreach(var c in values) {
-				result[i++] = Convert.ToSingle(c);
+            for (int i = 0; i < result.Length; i++) {
+				result[i] = Convert.ToSingle(values[i]);
 			}
 			return result;
 		}
 		case 'd':// floating point 8 -> double[]
 		{
 			var result = new double[values.Count];
-			int i = 0;
-			foreach(var c in values) {
-				result[i++] = Convert.ToDouble(c);
+            for (int i = 0; i < result.Length; i++) {
+				result[i] = Convert.ToDouble(values[i]);
 			}
 			return result;
 		}
@@ -296,89 +286,105 @@ public class ArrayConstructor : IObjectConstructor {
 	}
 
 	protected int[] constructIntArrayFromInt32(int machinecode, byte[] data) {
-		var result=new int[data.Length/4];
-		var bigendian=new byte[4];
-		for(int i=0; i<data.Length/4; i++) {
-			if(machinecode==8) {
-				result[i]=PickleUtils.bytes_to_integer(data, i*4, 4);
-			} else {
-				// big endian, swap
-				bigendian[0]=data[3+i*4];
-				bigendian[1]=data[2+i*4];
-				bigendian[2]=data[1+i*4];
-				bigendian[3]=data[0+i*4];
-				result[i]=PickleUtils.bytes_to_integer(bigendian);
-			}
-		}
+		var result = new int[data.Length/4];
+        if (machinecode == 8) {
+            for (int i = 0; i < result.Length; i++) {
+                result[i] = PickleUtils.bytes_to_integer(data, i * 4, 4);
+            }
+        }
+        else
+        {
+		    var bigendian = new byte[4];
+            for (int i = 0; i < result.Length; i++) {
+                // big endian, swap
+                bigendian[0] = data[3 + i * 4];
+                bigendian[1] = data[2 + i * 4];
+                bigendian[2] = data[1 + i * 4];
+                bigendian[3] = data[0 + i * 4];
+                result[i] = PickleUtils.bytes_to_integer(bigendian);
+            }
+        }
 		return result;
 	}
 
 	protected uint[] constructUIntArrayFromUInt32(int machinecode, byte[] data) {
 		var result=new uint[data.Length/4];
-		var bigendian=new byte[4];
-		for(int i=0; i<data.Length/4; i++) {
-			if(machinecode==6) {
-				result[i]=PickleUtils.bytes_to_uint(data, i*4);
-			} else {
+        if (machinecode == 6) {
+            for (int i = 0; i < result.Length; i++) {
+				result[i] = PickleUtils.bytes_to_uint(data, i*4);
+            }
+        }
+        else
+        {
+		    var bigendian = new byte[4];
+            for (int i = 0; i < result.Length; i++) {
 				// big endian, swap
 				bigendian[0]=data[3+i*4];
 				bigendian[1]=data[2+i*4];
 				bigendian[2]=data[1+i*4];
 				bigendian[3]=data[0+i*4];
 				result[i]=PickleUtils.bytes_to_uint(bigendian, 0);
-			}
-		}
+            }
+        }
 		return result;
 	}
 
 	protected ulong[] constructULongArrayFromUInt64(int machinecode, byte[] data) {
-		var result=new ulong[data.Length/8];
-		var swapped=new byte[8];
-		if(BitConverter.IsLittleEndian) {
-    		for(int i=0; i<data.Length/8; i++) {
-		        if(machinecode==10) {
-		            result[i]=BitConverter.ToUInt64(data, i*8);
-		        } else {
-    				swapped[0]=data[7+i*8];
-    				swapped[1]=data[6+i*8];
-    				swapped[2]=data[5+i*8];
-    				swapped[3]=data[4+i*8];
-    				swapped[4]=data[3+i*8];
-    				swapped[5]=data[2+i*8];
-    				swapped[6]=data[1+i*8];
-    				swapped[7]=data[0+i*8];
-		            result[i]=BitConverter.ToUInt64(swapped, 0);
-		        }
-		    }
-		} else {
-    		for(int i=0; i<data.Length/8; i++) {
-		        if(machinecode==11) {
-		            result[i]=BitConverter.ToUInt64(data, i*8);
-		        } else {
-    				swapped[0]=data[7+i*8];
-    				swapped[1]=data[6+i*8];
-    				swapped[2]=data[5+i*8];
-    				swapped[3]=data[4+i*8];
-    				swapped[4]=data[3+i*8];
-    				swapped[5]=data[2+i*8];
-    				swapped[6]=data[1+i*8];
-    				swapped[7]=data[0+i*8];
-		            result[i]=BitConverter.ToUInt64(swapped, 0);
-		        }
-		    }
-		    
-		}
+		var result = new ulong[data.Length/8];
+        if (BitConverter.IsLittleEndian) {
+            if (machinecode == 10) {
+                for (int i = 0; i < result.Length; i++) {
+                    result[i] = BitConverter.ToUInt64(data, i * 8);
+                }
+            } else {
+                var swapped = new byte[8];
+                for (int i = 0; i < result.Length; i++) {
+                    swapped[0] = data[7 + i * 8];
+                    swapped[1] = data[6 + i * 8];
+                    swapped[2] = data[5 + i * 8];
+                    swapped[3] = data[4 + i * 8];
+                    swapped[4] = data[3 + i * 8];
+                    swapped[5] = data[2 + i * 8];
+                    swapped[6] = data[1 + i * 8];
+                    swapped[7] = data[0 + i * 8];
+                    result[i] = BitConverter.ToUInt64(swapped, 0);
+                }
+            }
+        } else {
+            if (machinecode == 11) {
+                for (int i = 0; i < result.Length; i++) {
+                    result[i] = BitConverter.ToUInt64(data, i * 8);
+                }
+            }
+            else
+            {
+                var swapped = new byte[8];
+                for (int i = 0; i < result.Length; i++) {
+                    swapped[0] = data[7 + i * 8];
+                    swapped[1] = data[6 + i * 8];
+                    swapped[2] = data[5 + i * 8];
+                    swapped[3] = data[4 + i * 8];
+                    swapped[4] = data[3 + i * 8];
+                    swapped[5] = data[2 + i * 8];
+                    swapped[6] = data[1 + i * 8];
+                    swapped[7] = data[0 + i * 8];
+                    result[i] = BitConverter.ToUInt64(swapped, 0);
+                }
+            }
+        }
 		return result;
 	}
 
 	protected long[] constructLongArrayFromInt64(int machinecode, byte[] data) {
 		var result=new long[data.Length/8];
-		var bigendian=new byte[8];
-		for(int i=0; i<data.Length/8; i++) {
-			if(machinecode==12) {
-				// little endian can go
+        if (machinecode == 12) {
+            for (int i = 0; i < result.Length; i++) {
 				result[i]=PickleUtils.bytes_to_long(data, i*8);
-			} else {
+            }
+        }
+        else { 
+		    var bigendian=new byte[8];
+            for (int i = 0; i < result.Length; i++) {
 				// 13=big endian, swap
 				bigendian[0]=data[7+i*8];
 				bigendian[1]=data[6+i*8];
@@ -396,12 +402,14 @@ public class ArrayConstructor : IObjectConstructor {
 
 	protected double[] constructDoubleArray(int machinecode, byte[] data) {
 		var result = new double[data.Length / 8];
-		var bigendian=new byte[8];
-		for (int i = 0; i < data.Length / 8; ++i) {
-			if(machinecode==17) {
-				result[i] = PickleUtils.bytes_bigendian_to_double(data, i * 8);
-			} else {
-				// 16=little endian, flip the bytes
+        if (machinecode == 17) {
+            for (int i = 0; i < result.Length; i++) {
+                result[i] = PickleUtils.bytes_bigendian_to_double(data, i * 8);
+            }
+        } else {
+		    var bigendian=new byte[8];
+            for (int i = 0; i < result.Length; i++) {
+                // 16=little endian, flip the bytes
 				bigendian[0]=data[7+i*8];
 				bigendian[1]=data[6+i*8];
 				bigendian[2]=data[5+i*8];
@@ -411,67 +419,77 @@ public class ArrayConstructor : IObjectConstructor {
 				bigendian[6]=data[1+i*8];
 				bigendian[7]=data[0+i*8];
 				result[i] = PickleUtils.bytes_bigendian_to_double(bigendian, 0);
-			}
-		}
+            }
+        }
 		return result;
 	}
 
 	protected float[] constructFloatArray(int machinecode, byte[] data) {
 		var result = new float[data.Length / 4];
-		var bigendian=new byte[4];
-		for (int i = 0; i < data.Length / 4; ++i) {
-			if (machinecode == 15) {
-				result[i] = PickleUtils.bytes_bigendian_to_float(data, i * 4);
-			} else {
+        if (machinecode == 15) {
+            for (int i = 0; i < result.Length; i++) {
+                result[i] = PickleUtils.bytes_bigendian_to_float(data, i * 4);
+            }
+        } else {
+		    var bigendian=new byte[4];
+            for (int i = 0; i < result.Length; i++) {
 				// 14=little endian, flip the bytes
 				bigendian[0]=data[3+i*4];
 				bigendian[1]=data[2+i*4];
 				bigendian[2]=data[1+i*4];
 				bigendian[3]=data[0+i*4];
 				result[i] = PickleUtils.bytes_bigendian_to_float(bigendian, 0);
-			}
-		}
+            }
+        }
 		return result;
 	}
 
 	protected ushort[] constructUShortArrayFromUShort(int machinecode, byte[] data) {
 		var result = new ushort[data.Length / 2];
-		for(int i=0; i<data.Length/2; ++i) {
-			ushort b1=data[0+i*2];
-			ushort b2=data[1+i*2];
-			if(machinecode==2) {
+        if (machinecode == 2) {
+            for (int i = 0; i < result.Length; i++) {
+                ushort b1=data[0+i*2];
+			    ushort b2=data[1+i*2];
 			    result[i] = (ushort)((b2<<8) | b1);
-			} else {
+            }
+        } else {
+            for (int i = 0; i < result.Length; i++) {
+                ushort b1=data[0+i*2];
+			    ushort b2=data[1+i*2];
 				// big endian
 				result[i] = (ushort)((b1<<8) | b2);
-			}
-		}
+            }
+        }
 		return result;
 	}
 
 	protected short[] constructShortArraySigned(int machinecode, byte[] data) {
 		var result = new short[data.Length / 2];
-		var swapped=new byte[2];
 		if(BitConverter.IsLittleEndian) {
-    		for(int i=0; i<data.Length/2; ++i) {
-    			if(machinecode==4) {
+            if (machinecode == 4) { 
+                for (int i = 0; i < result.Length; i++) {
 		            result[i]=BitConverter.ToInt16(data, i*2);
-    			} else {
-		            swapped[0]=data[1+i*2];
+                }
+            } else {
+		        var swapped=new byte[2];
+                for (int i = 0; i < result.Length; i++) {
+                    swapped[0] = data[1+i*2];
 		            swapped[1]=data[0+i*2];
     			    result[i]=BitConverter.ToInt16(swapped,0);
-    			}
-    		}
+                }
+            }
 		} else {
-		    // big endian
-    		for(int i=0; i<data.Length/2; ++i) {
-    			if(machinecode==5) {
+            if (machinecode == 5) { 
+                for (int i = 0; i < result.Length; i++) {
     			    result[i]=BitConverter.ToInt16(data, i*2);
-    			} else {
-		            swapped[0]=data[1+i*2];
+                }
+            } else {
+		        var swapped=new byte[2];
+                for (int i = 0; i < result.Length; i++) {
+                    swapped[0]=data[1+i*2];
 		            swapped[1]=data[0+i*2];
     			    result[i]=BitConverter.ToInt16(swapped,0);
-    			}
+                }
     		}
 		}
 		return result;
@@ -479,17 +497,18 @@ public class ArrayConstructor : IObjectConstructor {
 
 	protected char[] constructCharArrayUTF32(int machinecode, byte[] data) {
 		var result = new char[data.Length / 4];
-		var bigendian=new byte[4];
-		for (int index = 0; index < data.Length / 4; ++index) {
-			if (machinecode == 20) { 
+        if (machinecode == 20) {
+            for (int index = 0; index < result.Length; ++index) {
 		        int codepoint=PickleUtils.bytes_to_integer(data, index*4, 4);
 		        string cc=char.ConvertFromUtf32(codepoint);
-				if(cc.Length>1)
+                if (cc.Length>1)
 					throw new PickleException("cannot process UTF-32 character codepoint "+codepoint);
 		        result[index] = cc[0];
-			}
-			else {
-				// big endian, swap
+            }
+        } else {
+		    var bigendian=new byte[4];
+            for (int index = 0; index < result.Length; ++index) {
+                // big endian, swap
 				bigendian[0]=data[3+index*4];
 				bigendian[1]=data[2+index*4];
 				bigendian[2]=data[1+index*4];
@@ -499,28 +518,28 @@ public class ArrayConstructor : IObjectConstructor {
 				if(cc.Length>1)
 					throw new PickleException("cannot process UTF-32 character codepoint "+codepoint);
 				result[index] = cc[0];
-			}
-		}
+            }
+        }
 		return result;
 	}
 
 	protected char[] constructCharArrayUTF16(int machinecode, byte[] data) {
 		var result = new char[data.Length / 2];
-		var bigendian=new byte[2];
-		for (int index = 0; index < data.Length / 2; ++index) {
-			if (machinecode == 18) { 
+        if (machinecode == 18) {
+		    for (int index = 0; index < result.Length; ++index) {
 				result[index] = (char) PickleUtils.bytes_to_integer(data, index*2, 2);
-			}
-			else {
-				// big endian, swap
+            }
+        } else {
+		    var bigendian=new byte[2];
+		    for (int index = 0; index < result.Length; ++index) {
+                // big endian, swap
 				bigendian[0]=data[1+index*2];
 				bigendian[1]=data[0+index*2];
 				result[index] = (char) PickleUtils.bytes_to_integer(bigendian);
-			}
-		}
+            }
+        }
 		return result;
 	}    
 }
-
 
 }

--- a/dotnet/Razorvine.Pyrolite/Pyrolite/Pickle/PickleUtils.cs
+++ b/dotnet/Razorvine.Pyrolite/Pyrolite/Pickle/PickleUtils.cs
@@ -274,13 +274,13 @@ public static class PickleUtils {
 	 * converted to the corresponding chars, without using a given character
 	 * encoding
 	 */
-	public static unsafe string rawStringFromBytes(byte[] data)
+	public static string rawStringFromBytes(byte[] data)
     {
         return rawStringFromBytes(new ReadOnlySpan<byte>(data));
     }
 
     internal static unsafe string rawStringFromBytes(ReadOnlySpan<byte> data) {
-        var result = new string('\0', data.Length);
+        var result = new string('\0', data.Length); // Use String.Create instead when it's available
         fixed (char* resultPtr = result)
         {
             for (int i = 0; i < data.Length; i++)

--- a/dotnet/Razorvine.Pyrolite/Pyrolite/Pickle/PickleUtils.cs
+++ b/dotnet/Razorvine.Pyrolite/Pyrolite/Pickle/PickleUtils.cs
@@ -1,6 +1,8 @@
 /* part of Pyrolite, by Irmen de Jong (irmen@razorvine.net) */
 
 using System;
+using System.Buffers.Binary;
+using System.Diagnostics;
 using System.IO;
 using System.Text;
 // ReSharper disable InconsistentNaming
@@ -22,9 +24,9 @@ public static class PickleUtils {
 		while (true) {
 			int c = input.ReadByte();
 			if (c == -1) {
-				if (sb.Length == 0)
-					throw new IOException("premature end of file");
-				break;
+                if (sb.Length == 0)
+                    ThrowPrematureEndOfInputStream();
+                break;
 			}
 			if (c != '\n' || includeLF)
 				sb.Append((char) c);
@@ -34,16 +36,57 @@ public static class PickleUtils {
 		return sb.ToString();
 	}
 
+    internal static int readline_into(Stream input, ref byte[] buffer, bool includeLF = false)
+    {
+        Debug.Assert(buffer != null);
+        byte[] localBuffer = buffer;
+
+        int count = 0;
+		while (true) {
+			int c = input.ReadByte();
+			if (c == -1) {
+				if (count == 0) ThrowPrematureEndOfInputStream();
+				break;
+			}
+			if (c != '\n' || includeLF)
+            {
+                if (count == localBuffer.Length)
+                {
+                    Array.Resize(ref localBuffer, localBuffer.Length == 0 ? 16 : localBuffer.Length * 2);
+                    buffer = localBuffer;
+                }
+                localBuffer[count++] = (byte)c;
+            }
+			if (c == '\n')
+			    break;
+		}
+
+		return count;
+    }
+
+    internal static bool IsWhitespace(ReadOnlySpan<byte> bytes)
+    {
+        for (int i = 0; i < bytes.Length; i++)
+        {
+            if (!char.IsWhiteSpace((char)bytes[i]))
+                return false;
+        }
+        return true;
+    }
+
 	/**
 	 * read a single unsigned byte
 	 */
 	public static byte readbyte(Stream input) {
 		int b = input.ReadByte();
 		if(b<0) {
-			throw new IOException("premature end of input stream");
+			ThrowPrematureEndOfInputStream();
 		}
 		return (byte)b;
 	}
+
+    private static void ThrowPrematureEndOfInputStream() =>
+        throw new IOException("premature end of input stream");
 
 	/**
 	 * read a number of signed bytes
@@ -59,8 +102,7 @@ public static class PickleUtils {
 	 */
 	public static byte[] readbytes(Stream input, long n) {
 		try {
-			int small_n = Convert.ToInt32(n);
-			return readbytes(input, small_n);
+			return readbytes(input, checked((int)n));
 		} catch (OverflowException x) {
 			throw new PickleException("pickle too large, can't read more than maxint", x);
 		}
@@ -73,9 +115,20 @@ public static class PickleUtils {
 		while (length > 0) {
 			int read = input.Read(buffer, offset, length);
 			if (read <= 0)
-				throw new IOException("read error; expected more bytes");
-			offset += read;
+                ThrowPrematureEndOfInputStream();
+            offset += read;
 			length -= read;
+		}
+	}
+
+    /**
+	 * read a number of signed bytes into the specified location in an existing byte array
+	 */
+	internal static void readbytes_into(Stream input, byte[] buffer, int offset, long length) {
+        try {
+			readbytes_into(input, buffer, offset, checked((int)length));
+		} catch (OverflowException x) {
+			throw new PickleException("pickle too large, can't read more than maxint", x);
 		}
 	}
 
@@ -167,9 +220,7 @@ public static class PickleUtils {
 			throw new PickleException("decoding double: too few bytes");
 	    }
     	if(BitConverter.IsLittleEndian) {
-			// reverse the bytes to make them littleendian for the bitconverter
-			byte[] littleendian={ bytes[7+offset], bytes[6+offset], bytes[5+offset], bytes[4+offset], bytes[3+offset], bytes[2+offset], bytes[1+offset], bytes[0+offset] };
-			return BitConverter.ToDouble(littleendian,0);
+            return BitConverter.Int64BitsToDouble(BinaryPrimitives.ReadInt64BigEndian(bytes.AsSpan(offset)));
 		}
 		return BitConverter.ToDouble(bytes,offset);
 	}
@@ -182,9 +233,8 @@ public static class PickleUtils {
 			throw new PickleException("decoding float: too few bytes");
 	    }
     	if(BitConverter.IsLittleEndian) {
-			// reverse the bytes to make them littleendian for the bitconverter
-			byte[] littleendian={ bytes[3+offset], bytes[2+offset], bytes[1+offset], bytes[0+offset] };
-			return BitConverter.ToSingle(littleendian,0);
+            int intVal = BinaryPrimitives.ReadInt32BigEndian(bytes.AsSpan(offset));
+            unsafe { return *(float*)&intVal; };
 		}
 		return BitConverter.ToSingle(bytes,offset);
 	}
@@ -198,7 +248,7 @@ public static class PickleUtils {
 		if (data.Length == 0)
 			return 0L;
 		if (data.Length>8)
-			throw new PickleException("value to large for long, biginteger needed");
+			throw new PickleException("value too large for long, biginteger needed");
 		if( data.Length<8) {
 			// bitconverter requires exactly 8 bytes so we need to extend it
 			var larger=new byte[8];
@@ -224,12 +274,19 @@ public static class PickleUtils {
 	 * converted to the corresponding chars, without using a given character
 	 * encoding
 	 */
-	public static string rawStringFromBytes(byte[] data) {
-		StringBuilder str = new StringBuilder(data.Length);
-		foreach (byte b in data) {
-			str.Append((char)b);
-		}
-		return str.ToString();
+	public static unsafe string rawStringFromBytes(byte[] data)
+    {
+        return rawStringFromBytes(new ReadOnlySpan<byte>(data));
+    }
+
+    internal static unsafe string rawStringFromBytes(ReadOnlySpan<byte> data) {
+        var result = new string('\0', data.Length);
+        fixed (char* resultPtr = result)
+        {
+            for (int i = 0; i < data.Length; i++)
+                resultPtr[i] = (char)data[i];
+        }
+        return result;
 	}
 	
 	/**

--- a/dotnet/Razorvine.Pyrolite/Pyrolite/Pickle/UnpickleStack.cs
+++ b/dotnet/Razorvine.Pyrolite/Pyrolite/Pickle/UnpickleStack.cs
@@ -1,5 +1,6 @@
 /* part of Pyrolite, by Irmen de Jong (irmen@razorvine.net) */
 
+using System;
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 
@@ -11,31 +12,42 @@ namespace Razorvine.Pickle
 /// </summary>
 [SuppressMessage("ReSharper", "InconsistentNaming")]
 public class UnpickleStack {
-	private readonly ArrayList _stack;
 	public readonly object MARKER;
+    private const int DefaultCapacity = 4;
+	private object[] _stack;
+    private int _count;
 
 	public UnpickleStack() {
-		_stack = new ArrayList();
+		_stack = new object[DefaultCapacity];
 		MARKER = new object(); // any new unique object
 	}
 
-	public void add(object o) {
-		_stack.Add(o);
-	}
+    public void add(object o)
+    {
+        if (_count == _stack.Length)
+        {
+            Array.Resize(ref _stack, _count * 2);
+        }
+
+        _stack[_count++] = o;
+    }
 
 	public void add_mark() {
-		_stack.Add(MARKER);
+		add(MARKER);
 	}
 
-	public object pop() {
-		int size = _stack.Count;
-		var result = _stack[size - 1];
-		_stack.RemoveAt(size-1);
-		return result;
-	}
+    public object pop()
+    {
+        if (_count == 0)
+        {
+            throw new ArgumentOutOfRangeException("index"); // match exception type/parameter name thrown from ArrayList used previously
+        }
+
+        return _stack[--_count];
+    }
 
 	public ArrayList pop_all_since_marker() {
-		ArrayList result = new ArrayList();
+		var result = new ArrayList();
 		object o = pop();
 		while (o != MARKER) {
 			result.Add(o);
@@ -46,21 +58,39 @@ public class UnpickleStack {
 		return result;
 	}
 
+    internal object[] pop_all_since_marker_as_array()
+    {
+        int i = _count - 1;
+        while (_stack[i] != MARKER)
+            i--;
+
+        var result = new object[_count - 1 - i];
+        Array.Copy(_stack, i + 1, result, 0, result.Length);
+
+        _count = i;
+        return result;
+    }
+
 	public object peek() {
-		return _stack[_stack.Count-1];
-	}
+        return _stack[_count - 1];
+    }
 
 	public void trim() {
-		_stack.TrimToSize();
+        if (_count < _stack.Length && _stack.Length > DefaultCapacity)
+        {
+            var newArr = new object[Math.Max(_count, DefaultCapacity)];
+            Array.Copy(_stack, 0, newArr, 0, _count);
+            _stack = newArr;
+        }
 	}
 
 	public int size() {
-		return _stack.Count;
+		return _count;
 	}
 
 	public void clear() {
-		_stack.Clear();
-		_stack.TrimToSize();
+        _count = 0;
+		trim();
 	}
 }
 

--- a/dotnet/Razorvine.Pyrolite/Pyrolite/Pickle/Unpickler.cs
+++ b/dotnet/Razorvine.Pyrolite/Pyrolite/Pickle/Unpickler.cs
@@ -519,10 +519,7 @@ public class Unpickler : IDisposable {
         long len = BinaryPrimitives.ReadInt64LittleEndian(byteBuffer);
         EnsureByteBufferLength(len);
         PickleUtils.readbytes_into(input, byteBuffer, 0, len);
-        fixed (byte* lineByteBufferPtr = byteBuffer)
-        {
-            stack.add(Encoding.UTF8.GetString(lineByteBufferPtr, (int)len));
-        }
+        stack.add(Encoding.UTF8.GetString(byteBuffer, 0, (int)len));
 	}
 
 	private void load_short_binunicode() {

--- a/dotnet/Razorvine.Pyrolite/Pyrolite/Pickle/Unpickler.cs
+++ b/dotnet/Razorvine.Pyrolite/Pyrolite/Pickle/Unpickler.cs
@@ -1,8 +1,12 @@
 /* part of Pyrolite, by Irmen de Jong (irmen@razorvine.net) */
 
 using System;
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Buffers.Text;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
@@ -29,11 +33,26 @@ public class Unpickler : IDisposable {
 	protected readonly IDictionary<int, object> memo;
 	protected UnpickleStack stack;
 	protected Stream input;
-	protected static readonly IDictionary<string, IObjectConstructor> objectConstructors;
+	protected static readonly IDictionary<string, IObjectConstructor> objectConstructors = CreateObjectConstructorsDictionary();
 	protected static readonly object NO_RETURN_VALUE = new object();
+    private static readonly string[] quoteStrings = new [] { "\"", "'" };
+    private static readonly object boxedFalse = false;
+    private static readonly object boxedTrue = true;
+    private byte[] byteBuffer = new byte[sizeof(long)]; // at least large enough for any primitive being deserialized
+    private Dictionary<StringPair, string> concatenatedModuleNames;
 
-	static Unpickler() {
-		objectConstructors = new Dictionary<string, IObjectConstructor>
+    private readonly struct StringPair : IEquatable<StringPair>
+    {
+        public readonly string Item1, Item2;
+        public StringPair(string item1, string item2) { Item1 = item1; Item2 = item2; }
+        public bool Equals(StringPair other) => Item1 == other.Item1 && Item2 == other.Item2;
+        public override bool Equals(object obj) => obj is StringPair sp && Equals(sp);
+        public override int GetHashCode() => Item1.GetHashCode() ^ Item2.GetHashCode();
+    }
+
+    private static Dictionary<string, IObjectConstructor> CreateObjectConstructorsDictionary()
+    {
+        return new Dictionary<string, IObjectConstructor>(15)
 		{
 			["__builtin__.complex"] = new AnyClassConstructor(typeof(ComplexNumber)),
 			["builtins.complex"] = new AnyClassConstructor(typeof(ComplexNumber)),
@@ -341,34 +360,45 @@ public class Unpickler : IDisposable {
 	}
 
 	private void load_false() {
-		stack.add(false);
+		stack.add(boxedFalse);
 	}
 
 	private void load_true() {
-		stack.add(true);
+		stack.add(boxedTrue);
 	}
 
-	private void load_int() {
-		string data = PickleUtils.readline(input, true);
-		object val;
-		if (data==Opcodes.FALSE.Substring(1))
-			val = false;
-		else if (data==Opcodes.TRUE.Substring(1))
-			val = true;
-		else {
-			string number=data.Substring(0, data.Length - 1);
-			try {
-				val=int.Parse(number);
-			} catch (OverflowException) {
-				// hmm, integer didnt' work.. is it perhaps an int from a 64-bit python? so try long:
-				val = long.Parse(number);
-			}
-		}
-		stack.add(val);
-	}
+    private void load_int() {
+        int len = PickleUtils.readline_into(input, ref byteBuffer, includeLF: true);
+        object val;
+        if (len == 3 && byteBuffer[2] == (byte)'\n' && byteBuffer[0] == (byte)'0') {
+            if (byteBuffer[1] == (byte)'0') {
+                load_false();
+                return;
+            }
+            else if (byteBuffer[1] == (byte)'1') {
+                load_true();
+                return;
+            }
+        }
+
+        len--;
+        if (len > 0 && Utf8Parser.TryParse(byteBuffer.AsSpan(0, len), out int intNumber, out int bytesConsumed) && bytesConsumed == len) {
+            val = intNumber;
+        }
+        else if (len > 0 && Utf8Parser.TryParse(byteBuffer.AsSpan(0, len), out long longNumber, out bytesConsumed) && bytesConsumed == len) {
+            val = longNumber;
+        }
+        else {
+            val = long.Parse(PickleUtils.rawStringFromBytes(byteBuffer.AsSpan(0, len)));
+            Debug.Fail("long.Parse should have thrown.");
+        }
+
+        stack.add(val);
+    }
 
 	private void load_binint()  {
-		int integer = PickleUtils.bytes_to_integer(PickleUtils.readbytes(input, 4));
+        PickleUtils.readbytes_into(input, byteBuffer, 0, sizeof(int));
+		int integer = BinaryPrimitives.ReadInt32LittleEndian(byteBuffer);
 		stack.add(integer);
 	}
 
@@ -377,7 +407,8 @@ public class Unpickler : IDisposable {
 	}
 
 	private void load_binint2() {
-		int integer = PickleUtils.bytes_to_integer(PickleUtils.readbytes(input, 2));
+        PickleUtils.readbytes_into(input, byteBuffer, 0, sizeof(short));
+		int integer = BinaryPrimitives.ReadUInt16LittleEndian(byteBuffer);
 		stack.add(integer);
 	}
 
@@ -401,26 +432,32 @@ public class Unpickler : IDisposable {
 	}
 
 	private void load_long4() {
-		int n = PickleUtils.bytes_to_integer(PickleUtils.readbytes(input, 4));
+        PickleUtils.readbytes_into(input, byteBuffer, 0, sizeof(int));
+		int n = BinaryPrimitives.ReadInt32LittleEndian(byteBuffer);
 		var data = PickleUtils.readbytes(input, n);
 		stack.add(PickleUtils.decode_long(data));
 	}
 
 	private void load_float() {
-		string val = PickleUtils.readline(input, true);
-		double d=double.Parse(val, NumberStyles.Float|NumberStyles.AllowDecimalPoint|NumberStyles.AllowLeadingSign, NumberFormatInfo.InvariantInfo);
+        int len = PickleUtils.readline_into(input, ref byteBuffer, includeLF: true);
+        ReadOnlySpan<byte> bytes = byteBuffer.AsSpan(0, len);
+        if (!Utf8Parser.TryParse(bytes, out double d, out int bytesConsumed) || !PickleUtils.IsWhitespace(bytes.Slice(bytesConsumed)))
+        {
+            throw new FormatException();
+        }
 		stack.add(d);
 	}
 
 	private void load_binfloat() {
-		double val = PickleUtils.bytes_bigendian_to_double(PickleUtils.readbytes(input, 8),0);
+        PickleUtils.readbytes_into(input, byteBuffer, 0, sizeof(long));
+        double val = BitConverter.Int64BitsToDouble(BinaryPrimitives.ReadInt64BigEndian(byteBuffer));
 		stack.add(val);
 	}
 
 	private void load_string() {
 		string rep = PickleUtils.readline(input);
 		bool quotesOk = false;
-		foreach (string q in new [] { "\"", "'" }) // double or single quote
+		foreach (string q in quoteStrings) // double or single quote
 		{
 			if (rep.StartsWith(q)) {
 				if (!rep.EndsWith(q)) {
@@ -439,18 +476,22 @@ public class Unpickler : IDisposable {
 	}
 
 	private void load_binstring() {
-		int len = PickleUtils.bytes_to_integer(PickleUtils.readbytes(input, 4));
-		var data = PickleUtils.readbytes(input, len);
-		stack.add(PickleUtils.rawStringFromBytes(data));
+        PickleUtils.readbytes_into(input, byteBuffer, 0, sizeof(int));
+		int len = BinaryPrimitives.ReadInt32LittleEndian(byteBuffer);
+        EnsureByteBufferLength(len);
+        PickleUtils.readbytes_into(input, byteBuffer, 0, len);
+		stack.add(PickleUtils.rawStringFromBytes(byteBuffer.AsSpan(0, len)));
 	}
 
 	private void load_binbytes() {
-		int len = PickleUtils.bytes_to_integer(PickleUtils.readbytes(input, 4));
+        PickleUtils.readbytes_into(input, byteBuffer, 0, sizeof(int));
+		int len = BinaryPrimitives.ReadInt32LittleEndian(byteBuffer);
 		stack.add(PickleUtils.readbytes(input, len));
 	}
 
 	private void load_binbytes8() {
-		long len = PickleUtils.bytes_to_long(PickleUtils.readbytes(input, 8),0);
+        PickleUtils.readbytes_into(input, byteBuffer, 0, sizeof(long));
+        long len = BinaryPrimitives.ReadInt64LittleEndian(byteBuffer);
 		stack.add(PickleUtils.readbytes(input, len));
 	}
 
@@ -460,15 +501,28 @@ public class Unpickler : IDisposable {
 	}
 
 	private void load_binunicode() {
-		int len = PickleUtils.bytes_to_integer(PickleUtils.readbytes(input, 4));
+        PickleUtils.readbytes_into(input, byteBuffer, 0, sizeof(int));
+		int len = BinaryPrimitives.ReadInt32LittleEndian(byteBuffer);
 		var data = PickleUtils.readbytes(input, len);
 		stack.add(Encoding.UTF8.GetString(data));
 	}
 
-	private void load_binunicode8() {
-		long len = PickleUtils.bytes_to_long(PickleUtils.readbytes(input, 8),0);
-		var data = PickleUtils.readbytes(input, len);
-		stack.add(Encoding.UTF8.GetString(data));
+    private void EnsureByteBufferLength(long len) {
+        if (len > byteBuffer.Length)
+        {
+            byteBuffer = new byte[Math.Max(len, byteBuffer.Length * 2)];
+        }
+    }
+
+	private unsafe void load_binunicode8() {
+        PickleUtils.readbytes_into(input, byteBuffer, 0, sizeof(long));
+        long len = BinaryPrimitives.ReadInt64LittleEndian(byteBuffer);
+        EnsureByteBufferLength(len);
+        PickleUtils.readbytes_into(input, byteBuffer, 0, len);
+        fixed (byte* lineByteBufferPtr = byteBuffer)
+        {
+            stack.add(Encoding.UTF8.GetString(lineByteBufferPtr, (int)len));
+        }
 	}
 
 	private void load_short_binunicode() {
@@ -479,8 +533,9 @@ public class Unpickler : IDisposable {
 
 	private void load_short_binstring() {
 		byte len = PickleUtils.readbyte(input);
-		var data = PickleUtils.readbytes(input, len);
-		stack.add(PickleUtils.rawStringFromBytes(data));
+        EnsureByteBufferLength(len);
+		PickleUtils.readbytes_into(input, byteBuffer, 0, len);
+		stack.add(PickleUtils.rawStringFromBytes(byteBuffer.AsSpan(0, len)));
 	}
 
 	private void load_short_binbytes() {
@@ -489,12 +544,11 @@ public class Unpickler : IDisposable {
 	}
 
 	private void load_tuple() {
-		ArrayList top=stack.pop_all_since_marker();
-		stack.add(top.ToArray());
+		stack.add(stack.pop_all_since_marker_as_array());
 	}
 
 	private void load_empty_tuple() {
-		stack.add(new object[0]);
+		stack.add(Array.Empty<object>());
 	}
 
 	private void load_tuple1() {
@@ -532,9 +586,9 @@ public class Unpickler : IDisposable {
 	}
 
 	private void load_dict() {
-		ArrayList top = stack.pop_all_since_marker();
-		Hashtable map=new Hashtable(top.Count);
-		for (int i = 0; i < top.Count; i += 2) {
+		object[] top = stack.pop_all_since_marker_as_array();
+		Hashtable map=new Hashtable(top.Length);
+		for (int i = 0; i < top.Length; i += 2) {
 			object key = top[i];
 			object value = top[i+1];
 			map[key]=value;
@@ -543,7 +597,7 @@ public class Unpickler : IDisposable {
 	}
 
 	private void load_frozenset() {
-		ArrayList top = stack.pop_all_since_marker();
+		object[] top = stack.pop_all_since_marker_as_array();
 		var set = new HashSet<object>();
 		foreach(var element in top)
 			set.Add(element);
@@ -551,7 +605,7 @@ public class Unpickler : IDisposable {
 	}
 
 	private void load_additems() {
-		ArrayList top = stack.pop_all_since_marker();
+		object[] top = stack.pop_all_since_marker_as_array();
 		var set = (HashSet<object>) stack.pop();
 		foreach(object item in top)
 			set.Add(item);
@@ -559,9 +613,13 @@ public class Unpickler : IDisposable {
 	}
 
 	private void load_global() {
-		string module = PickleUtils.readline(input);
-		string name = PickleUtils.readline(input);
-		load_global_sub(module, name);
+        int stringLen = PickleUtils.readline_into(input, ref byteBuffer);
+        string module = Encoding.UTF8.GetString(byteBuffer, 0, stringLen);
+
+        stringLen = PickleUtils.readline_into(input, ref byteBuffer);
+        string name = Encoding.UTF8.GetString(byteBuffer, 0, stringLen);
+
+        load_global_sub(module, name);
 	}
 
 	private void load_stack_global() {
@@ -570,41 +628,47 @@ public class Unpickler : IDisposable {
 		load_global_sub(module, name);
 	}
 
-	private void load_global_sub(string module, string name) {
-		IObjectConstructor constructor;
-		string key=module+"."+name;
-		if(objectConstructors.ContainsKey(key)) {
-			 constructor = objectConstructors[module + "." + name];
-		} else
-		{
-			switch (module)
-			{
-				// check if it is an exception
-				case "exceptions":
-					// python 2.x
-					constructor=new ExceptionConstructor(typeof(PythonException), module, name);
-					break;
-				case "builtins":
-				case "__builtin__":
-					if(name.EndsWith("Error") || name.EndsWith("Warning") || name.EndsWith("Exception")
-					   || name=="GeneratorExit" || name=="KeyboardInterrupt"
-					   || name=="StopIteration" || name=="SystemExit")
-					{
-						// it's a python 3.x exception
-						constructor=new ExceptionConstructor(typeof(PythonException), module, name);
-					}
-					else
-					{
-						// return a dictionary with the class's properties
-						constructor=new ClassDictConstructor(module, name);
-					}
+    private string GetModuleNameKey(string module, string name) {
+        if (concatenatedModuleNames == null) {
+            concatenatedModuleNames = new Dictionary<StringPair, string>();
+        }
 
-					break;
-				default:
-					constructor=new ClassDictConstructor(module, name);
-					break;
-			}
-		}
+        var sp = new StringPair(module, name);
+        if (!concatenatedModuleNames.TryGetValue(sp, out string key)) {
+            key = module + "." + name;
+            concatenatedModuleNames.Add(sp, key);
+        }
+
+        return key;
+    }
+
+	private void load_global_sub(string module, string name) {
+        if (!objectConstructors.TryGetValue(GetModuleNameKey(module, name), out IObjectConstructor constructor)) {
+            switch (module) {
+                // check if it is an exception
+                case "exceptions":
+                    // python 2.x
+                    constructor = new ExceptionConstructor(typeof(PythonException), module, name);
+                    break;
+                case "builtins":
+                case "__builtin__":
+                    if (name.EndsWith("Error") || name.EndsWith("Warning") || name.EndsWith("Exception")
+                        || name == "GeneratorExit" || name == "KeyboardInterrupt"
+                        || name == "StopIteration" || name == "SystemExit") {
+                        // it's a python 3.x exception
+                        constructor = new ExceptionConstructor(typeof(PythonException), module, name);
+                    }
+                    else {
+                        // return a dictionary with the class's properties
+                        constructor = new ClassDictConstructor(module, name);
+                    }
+
+                    break;
+                default:
+                    constructor = new ClassDictConstructor(module, name);
+                    break;
+            }
+        }
 		stack.add(constructor);		
 	}
 
@@ -637,7 +701,8 @@ public class Unpickler : IDisposable {
 	}
 
 	private void load_long_binget() {
-		int i = PickleUtils.bytes_to_integer(PickleUtils.readbytes(input, 4));
+        PickleUtils.readbytes_into(input, byteBuffer, 0, sizeof(int));
+		int i = BinaryPrimitives.ReadInt32LittleEndian(byteBuffer);
 		if(!memo.ContainsKey(i)) throw new PickleException("invalid memo key");
 		stack.add(memo[i]);
 	}
@@ -657,7 +722,8 @@ public class Unpickler : IDisposable {
 	}
 
 	private void load_long_binput() {
-		int i = PickleUtils.bytes_to_integer(PickleUtils.readbytes(input, 4));
+        PickleUtils.readbytes_into(input, byteBuffer, 0, sizeof(int));
+		int i = BinaryPrimitives.ReadInt32LittleEndian(byteBuffer);
 		memo[i]=stack.peek();
 	}
 
@@ -668,10 +734,11 @@ public class Unpickler : IDisposable {
 	}
 
 	private void load_appends() {
-		ArrayList top = stack.pop_all_since_marker();
+		object[] top = stack.pop_all_since_marker_as_array();
 		ArrayList list = (ArrayList) stack.peek();
-		list.AddRange(top);
-		list.TrimToSize();
+        for (int i = 0; i < top.Length; i++) {
+            list.Add(top[i]);
+        }
 	}
 
 	private void load_setitem() {
@@ -722,7 +789,7 @@ public class Unpickler : IDisposable {
 
 	private void load_frame() {
 		// for now we simply skip the frame opcode and its length
-		PickleUtils.readbytes(input, 8);
+        PickleUtils.readbytes_into(input, byteBuffer, 0, sizeof(long));
 	}
 
 	private void load_persid() {
@@ -738,27 +805,36 @@ public class Unpickler : IDisposable {
 	}
 
 	private void load_obj() {
-		ArrayList args = stack.pop_all_since_marker();
-		IObjectConstructor constructor = (IObjectConstructor)args[0];
-		args = args.GetRange(1, args.Count-1);
-		object obj = constructor.construct(args.ToArray());
-		stack.add(obj);
+		object[] popped = stack.pop_all_since_marker_as_array();
+
+        object[] args;
+        if (popped.Length > 1)
+        {
+            args = new object[popped.Length - 1];
+            Array.Copy(popped, 1, args, 0, args.Length);
+        }
+        else
+        {
+            args = Array.Empty<object>();
+        }
+
+		stack.add(((IObjectConstructor)popped[0]).construct(args));
 	}
 
 	private void load_inst() {
-		string module = PickleUtils.readline(input);
-		string classname = PickleUtils.readline(input);
-		ArrayList args = stack.pop_all_since_marker();
-		IObjectConstructor constructor;
-		if(objectConstructors.ContainsKey(module+"."+classname)) {
-			constructor = objectConstructors[module + "." + classname];
-		}
-		else {
+        int stringLen = PickleUtils.readline_into(input, ref byteBuffer);
+        string module = Encoding.UTF8.GetString(byteBuffer, 0, stringLen);
+
+        stringLen = PickleUtils.readline_into(input, ref byteBuffer);
+        string classname = Encoding.UTF8.GetString(byteBuffer, 0, stringLen);
+
+		object[] args = stack.pop_all_since_marker_as_array();
+
+		if(!objectConstructors.TryGetValue(GetModuleNameKey(module, classname), out IObjectConstructor constructor)) {
 			constructor = new ClassDictConstructor(module, classname);
-			args.Clear();  // classdict doesn't have constructor args... so we may lose info here, hmm.
+            args = Array.Empty<object>(); // classdict doesn't have constructor args... so we may lose info here, hmm.
 		}
-		object obj = constructor.construct(args.ToArray());
-		stack.add(obj);
+		stack.add(constructor.construct(args));
 	}
 	
 	protected virtual object persistentLoad(string pid)

--- a/dotnet/Razorvine.Pyrolite/Pyrolite/Pyrolite.csproj
+++ b/dotnet/Razorvine.Pyrolite/Pyrolite/Pyrolite.csproj
@@ -3,7 +3,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Razorvine.Pyrolite</AssemblyName>
     <RootNamespace>Razorvine</RootNamespace>
-    <LangVersion>6</LangVersion>
+    <LangVersion>7.3</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Authors>Irmen de Jong</Authors>
     <Product>Serpent Python literal expression serialization</Product>
     <PackageId>Razorvine.Pyrolite</PackageId>
@@ -24,5 +25,6 @@ More info about Pyro: https://pyro4.readthedocs.io/</Description>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Razorvine.Serpent" Version="1.25.0" />
+    <PackageReference Include="System.Memory" Version="4.5.2" />
   </ItemGroup>
 </Project>

--- a/dotnet/Razorvine.Pyrolite/Tests/Pickle/UnpickleComplexTests.cs
+++ b/dotnet/Razorvine.Pyrolite/Tests/Pickle/UnpickleComplexTests.cs
@@ -89,7 +89,7 @@ public class UnpickleComplexTests
 		UnpickleRealProxy(pickledProxy);
 	}
 
-	[Fact]
+	[Fact(Skip = "Failing with \"insecure string pickle\"")]
 	public void TestUnpickleProto0Bytes() {
 		var pickle = File.ReadAllBytes("pickled_bytes_level0.dat");
 

--- a/dotnet/Razorvine.Pyrolite/Tests/Pickle/UnpickleComplexTests.cs
+++ b/dotnet/Razorvine.Pyrolite/Tests/Pickle/UnpickleComplexTests.cs
@@ -89,7 +89,7 @@ public class UnpickleComplexTests
 		UnpickleRealProxy(pickledProxy);
 	}
 
-	[Fact(Skip = "Failing with \"insecure string pickle\"")]
+	[Fact] // fails on Windows due to "\r\n" line ending
 	public void TestUnpickleProto0Bytes() {
 		var pickle = File.ReadAllBytes("pickled_bytes_level0.dat");
 


### PR DESCRIPTION
Thanks for the helpful library!

I found while using it that it was generating a bunch of intermediate objects that could be avoided, and that these were contributing non-trivially to execution time.  This PR addresses many of them while also avoiding touching changing the public surface area, as I wasn't sure if it was malleable or not.  There's more that can be done in this regard, but for now this addresses a lot of the low-hanging fruit that's there.

(I also disabled one test that was failing prior to any of my changes.)

Example:
```C#
using System.IO;
using System.Linq;
using Razorvine.Pickle;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

[MemoryDiagnoser]
public class Test
{
    public static void Main() => BenchmarkRunner.Run<Test>();

    private readonly MemoryStream _stream = new MemoryStream();

    private object[][] _objectArrays = Enumerable.Range(0, 1000).Select(_ => new object[] { 1.0, 2.0 }).ToArray();
    private double[][] _doubleArrays = Enumerable.Range(0, 1000).Select(_ => new double[] { 1.0, 2.0 }).ToArray();
    private string[][] _stringArrays = Enumerable.Range(0, 1000).Select(_ => new string[] { "hello", "world" }).ToArray();

    [Benchmark] public void ObjectArrays() => PickleUnpickle(_objectArrays);
    [Benchmark] public void DoubleArrays() => PickleUnpickle(_doubleArrays);
    [Benchmark] public void StringArrays() => PickleUnpickle(_stringArrays);

    private void PickleUnpickle(object obj)
    {
        _stream.SetLength(0);
        new Pickler(useMemo: false).dump(obj, _stream);
        _stream.Position = 0;
        new Unpickler().load(_stream);
    }
}
```

Before:
```
|       Method |       Mean |     Error |   StdDev |    Gen 0 |   Gen 1 | Gen 2 |  Allocated |
|------------- |-----------:|----------:|---------:|---------:|--------:|------:|-----------:|
| ObjectArrays |   444.1 us |  9.490 us | 21.81 us |  78.6133 | 11.7188 |     - |  321.79 KB |
| DoubleArrays | 1,250.1 us | 26.046 us | 32.94 us | 312.5000 |       - |     - | 1282.73 KB |
| StringArrays |   633.2 us | 11.740 us | 12.06 us | 124.0234 |  1.9531 |     - |  509.29 KB |
```

After:
```
|       Method |     Mean |    Error |   StdDev |   Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------- |---------:|---------:|---------:|--------:|-------:|------:|----------:|
| ObjectArrays | 234.0 us | 2.081 us | 1.946 us | 26.8555 | 4.1504 |     - | 110.31 KB |
| DoubleArrays | 660.7 us | 5.529 us | 5.172 us | 89.8438 | 0.9766 |     - |  368.4 KB |
| StringArrays | 415.5 us | 3.102 us | 2.901 us | 61.0352 | 0.9766 |     - | 250.94 KB |
```

cc: @imback82, @eerhardt, @rapoth