### PR TITLE
Clear memo map after op code STOP

### DIFF
--- a/java/src/main/java/net/razorvine/pickle/Unpickler.java
+++ b/java/src/main/java/net/razorvine/pickle/Unpickler.java
@@ -159,6 +159,7 @@ public class Unpickler {
 		case Opcodes.STOP:
 			Object value = stack.pop();
 			stack.clear();
+			memo.clear();
 			return value;		// final result value
 		case Opcodes.POP:
 			load_pop();


### PR DESCRIPTION
Each unpickling should be independent. The memo map should not be reused without clearing between each `loads`/`load` call.

The added test shows the case that can cause wrong unpickled results. The serialized bytes were dumped from Python.